### PR TITLE
Support abbreviated addresses

### DIFF
--- a/src/AddressExtraction.php
+++ b/src/AddressExtraction.php
@@ -23,7 +23,7 @@ use MichielGerritsen\ExtractAddressParts\VO\AddressExtractionResult;
 
 class AddressExtraction
 {
-    const STREET_SPLIT_NAME_FROM_NUMBER = '/^(?P<street>\d*[\p{L}\d \'\/\\\\\-\.]+)[,\s]+(?P<housenumber>\d+)\s*(?P<addition>[\p{L} \d\-\/\'"\(\)]*)$/iu';
+    const STREET_SPLIT_NAME_FROM_NUMBER = '/^(?P<street>\d*[\p{L}\d \'\/\\\\\-]+)[,.\s]+(?P<housenumber>\d+)\s*(?P<addition>[\p{L} \d\-\/\'"\(\)]*)$/iu';
     const STREET_SPLIT_NUMBER_FROM_NAME = '/^(?P<housenumber>\d+)\s*(?P<street>[\p{L}\d \'\-\.]*)$/i';
 
     /**

--- a/tests/AddressExtractionTest.php
+++ b/tests/AddressExtractionTest.php
@@ -75,6 +75,14 @@ class AddressExtractionTest extends TestCase
                 ['95 Kerkstraat'],
                 new AddressExtractionResult('Kerkstraat', '95', '')
             ],
+            'Abbreviated address with dot' => [
+                ['Kerkstr. 8'],
+                new AddressExtractionResult('Kerkstr', '8', '')
+            ],
+            'Abbreviated address with dot without space' => [
+                ['Kerkstr.8'],
+                new AddressExtractionResult('Kerkstr', '8', '')
+            ],
         ];
     }
 


### PR DESCRIPTION
We sometimes encounter visitors using abbreviated address with a `.`. This currently fails the address parsing. This PR will support this type of address.